### PR TITLE
Update outdated link and add missing space

### DIFF
--- a/inst/pkgdown/templates/footer.html
+++ b/inst/pkgdown/templates/footer.html
@@ -1,8 +1,8 @@
 <div class="copyright">
-  <p>{{#package}}Developed by {{{authors}}}.{{/package}}</p>
+  <p>{{#package}}Developed by {{{authors}}}.{{/package}} </p>
 </div>
 
 <div class="pkgdown">
-  <p>Site built with <a href="http://hadley.github.io/pkgdown/">pkgdown</a>.</p>
+  <p>Site built with <a href="https://pkgdown.r-lib.org/">pkgdown</a>.</p>
 </div>
 


### PR DESCRIPTION
I'm not entirely sure whether the space should be here or before `{{/package}}` but it's missing right now: https://cransays.itsalocke.com/